### PR TITLE
Update github-enterprise-managed-user-provisioning-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
@@ -31,10 +31,6 @@ This tutorial describes the steps you need to perform in both GitHub Enterprise 
 > * Provision groups and group memberships in GitHub Enterprise Managed User
 > * Single sign-on to GitHub Enterprise Managed User (recommended)
 
-> [!NOTE]
-> This provisioning connector is enabled only for Enterprise Managed Users beta participants.
-
-
 ## Prerequisites
 
 The scenario outlined in this tutorial assumes that you already have the following prerequisites:


### PR DESCRIPTION
Remove beta status from Enterprise Managed Users since it was shipped to General Availability since Sep 30 2021.